### PR TITLE
feat: make dependabot update the template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,15 @@ updates:
       - "maintenance"
       - "dependencies"
 
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/_package/" # Location of package manifests
+    insecure-external-code-execution: allow
+    schedule:
+      interval: "weekly"
+    labels:
+      - "maintenance"
+      - "dependencies"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
As title says. Dependabot will now open PRs for the template project and the actual project.