### PR TITLE
fix: ``LICENSE`` file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,13 @@
 MIT License
 
-Copyright (c) 2023 - 2025 ANSYS, Inc. All rights reserved.
+Copyright (c) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.


### PR DESCRIPTION
``LICENSE`` file is not compliant with the PyAnsys requirements.

Closes #406.